### PR TITLE
docs(governance): add CODEOWNERS and branch protection policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Default owner for all files
+* @antonygiomarxdev
+
+# Critical governance and release surfaces
+/.github/workflows/ @antonygiomarxdev
+/.github/CODEOWNERS @antonygiomarxdev
+/ROADMAP.md @antonygiomarxdev
+/docs/adr/ @antonygiomarxdev
+
+# Core engine surfaces
+/crates/core/ @antonygiomarxdev
+/crates/storage/ @antonygiomarxdev
+/crates/sync/ @antonygiomarxdev
+/crates/server/ @antonygiomarxdev

--- a/docs/operations/workflow.md
+++ b/docs/operations/workflow.md
@@ -40,6 +40,21 @@ Every issue must include:
   - tests executed
 - No merge if CI is failing.
 
+## Repository Protection Baseline
+
+`main` must stay protected with:
+
+- pull request required (no direct push)
+- at least 1 approving review
+- stale review dismissal on new commits
+- resolved conversations required
+- required CI checks (Format, Clippy, Tests, Security Audit, Deny, Docs)
+- linear history required
+- force-push disabled
+- branch deletion disabled
+
+CODEOWNERS is defined in `.github/CODEOWNERS` to formalize ownership on critical surfaces.
+
 ## Label Taxonomy
 
 - Phase:


### PR DESCRIPTION
## Summary
- add .github/CODEOWNERS for ownership on critical surfaces
- document branch protection baseline in docs/operations/workflow.md
- main branch protection already applied via GitHub API (PR required + required checks + linear history)

## Why
- prevents direct pushes to main
- enforces review and CI gates consistently
- makes governance policy explicit in-repo

## Validation
- branch protection readback verified through gh api response
- docs-only change; no runtime impact