### PR TITLE
fix(sync): scope checkpoints by tenant+namespace in server responses

### DIFF
--- a/crates/server/src/routes.rs
+++ b/crates/server/src/routes.rs
@@ -189,6 +189,30 @@ impl ServerState {
     }
 }
 
+fn scoped_latest_checkpoint(
+    state: &ServerState,
+    tenant_id: &str,
+    namespace: &str,
+) -> Result<Checkpoint, RangoError> {
+    let latest = state.oplog.latest_seq()?;
+    if latest == 0 {
+        return Ok(Checkpoint::initial());
+    }
+
+    let entries = state.oplog.read_since(1, latest as usize + 1)?;
+    let scoped_latest = entries
+        .into_iter()
+        .filter(|entry| {
+            entry.mutation.metadata.tenant_id == tenant_id
+                && entry.mutation.metadata.namespace == namespace
+        })
+        .map(|entry| entry.seq)
+        .max()
+        .unwrap_or(0);
+
+    Ok(Checkpoint(scoped_latest))
+}
+
 #[derive(Debug, Clone, Copy, Default)]
 enum ContainmentMode {
     #[default]
@@ -264,7 +288,8 @@ pub async fn handle_push(
 
     if req.node_id != principal.node_id {
         state.non_owner_rejections.fetch_add(1, Ordering::Relaxed);
-        let new_checkpoint = Checkpoint(state.oplog.latest_seq().unwrap_or(0));
+        let new_checkpoint = scoped_latest_checkpoint(&state, &req.tenant_id, &req.namespace)
+            .unwrap_or_else(|_| Checkpoint::initial());
         return Ok(Json(PushResponse {
             accepted_seqs: Vec::new(),
             new_checkpoint,
@@ -288,7 +313,8 @@ pub async fn handle_push(
         let _ =
             state.persist_audit_evidence("write", &req.tenant_id, &req.namespace, None, &decision);
         state.register_decision_outcome(&req.tenant_id, &req.namespace, &decision);
-        let new_checkpoint = Checkpoint(state.oplog.latest_seq().unwrap_or(0));
+        let new_checkpoint = scoped_latest_checkpoint(&state, &req.tenant_id, &req.namespace)
+            .unwrap_or_else(|_| Checkpoint::initial());
         return Ok(Json(PushResponse {
             accepted_seqs: Vec::new(),
             new_checkpoint,
@@ -391,7 +417,8 @@ pub async fn handle_push(
         audit.push(decision);
     }
 
-    let new_checkpoint = Checkpoint(state.oplog.latest_seq().unwrap_or(0));
+    let new_checkpoint = scoped_latest_checkpoint(&state, &req.tenant_id, &req.namespace)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok(Json(PushResponse {
         accepted_seqs,
@@ -463,7 +490,8 @@ pub async fn handle_pull(
     if ControlPlane::is_reject(&read_decision) {
         return Ok(Json(PullResponse {
             mutations: Vec::new(),
-            new_checkpoint: Checkpoint(state.oplog.latest_seq().unwrap_or(0)),
+            new_checkpoint: scoped_latest_checkpoint(&state, &req.tenant_id, &req.namespace)
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
             audit: vec![read_decision],
         }));
     }
@@ -491,7 +519,8 @@ pub async fn handle_pull(
             *remaining -= 1;
         }
     }
-    let new_checkpoint = Checkpoint(state.oplog.latest_seq().unwrap_or(0));
+    let new_checkpoint = scoped_latest_checkpoint(&state, &req.tenant_id, &req.namespace)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok(Json(PullResponse {
         mutations,
@@ -609,7 +638,8 @@ pub async fn handle_promote(
         state.non_owner_rejections.fetch_add(1, Ordering::Relaxed);
         return Ok(Json(PromoteResponse {
             accepted_seqs: Vec::new(),
-            new_checkpoint: Checkpoint(state.oplog.latest_seq().unwrap_or(0)),
+            new_checkpoint: scoped_latest_checkpoint(&state, &req.tenant_id, &req.namespace)
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
             rejected_count: 1,
             audit: vec![GovernanceDecision {
                 decision: PolicyDecision::Reject,
@@ -624,7 +654,8 @@ pub async fn handle_promote(
             .fetch_add(1, Ordering::Relaxed);
         return Ok(Json(PromoteResponse {
             accepted_seqs: Vec::new(),
-            new_checkpoint: Checkpoint(state.oplog.latest_seq().unwrap_or(0)),
+            new_checkpoint: scoped_latest_checkpoint(&state, &req.tenant_id, &req.namespace)
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
             rejected_count: 1,
             audit: vec![GovernanceDecision {
                 decision: PolicyDecision::Reject,
@@ -636,7 +667,8 @@ pub async fn handle_promote(
     if let Err(err) = req.mutation.validate_metadata() {
         return Ok(Json(PromoteResponse {
             accepted_seqs: Vec::new(),
-            new_checkpoint: Checkpoint(state.oplog.latest_seq().unwrap_or(0)),
+            new_checkpoint: scoped_latest_checkpoint(&state, &req.tenant_id, &req.namespace)
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
             rejected_count: 1,
             audit: vec![GovernanceDecision {
                 decision: PolicyDecision::Reject,
@@ -653,7 +685,8 @@ pub async fn handle_promote(
             .fetch_add(1, Ordering::Relaxed);
         return Ok(Json(PromoteResponse {
             accepted_seqs: Vec::new(),
-            new_checkpoint: Checkpoint(state.oplog.latest_seq().unwrap_or(0)),
+            new_checkpoint: scoped_latest_checkpoint(&state, &req.tenant_id, &req.namespace)
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
             rejected_count: 1,
             audit: vec![GovernanceDecision {
                 decision: PolicyDecision::Reject,
@@ -681,7 +714,8 @@ pub async fn handle_promote(
         state.register_decision_outcome(&req.tenant_id, &req.namespace, &semantic_path_decision);
         return Ok(Json(PromoteResponse {
             accepted_seqs: Vec::new(),
-            new_checkpoint: Checkpoint(state.oplog.latest_seq().unwrap_or(0)),
+            new_checkpoint: scoped_latest_checkpoint(&state, &req.tenant_id, &req.namespace)
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
             rejected_count: 1,
             audit: vec![semantic_path_decision],
         }));
@@ -711,7 +745,8 @@ pub async fn handle_promote(
     if !matches!(decision.decision, PolicyDecision::Allow) {
         return Ok(Json(PromoteResponse {
             accepted_seqs: Vec::new(),
-            new_checkpoint: Checkpoint(state.oplog.latest_seq().unwrap_or(0)),
+            new_checkpoint: scoped_latest_checkpoint(&state, &req.tenant_id, &req.namespace)
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
             rejected_count: 1,
             audit: vec![decision],
         }));
@@ -721,7 +756,8 @@ pub async fn handle_promote(
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     Ok(Json(PromoteResponse {
         accepted_seqs: vec![seq],
-        new_checkpoint: Checkpoint(state.oplog.latest_seq().unwrap_or(seq)),
+        new_checkpoint: scoped_latest_checkpoint(&state, &req.tenant_id, &req.namespace)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
         rejected_count: 0,
         audit: vec![decision],
     }))

--- a/crates/server/tests/checkpoint_scope.rs
+++ b/crates/server/tests/checkpoint_scope.rs
@@ -1,0 +1,117 @@
+use std::sync::Arc;
+
+use bson::doc;
+use rango_oplog::FileOplog;
+use rango_server::{app, routes::ServerState};
+use rango_sync::client::SyncClient;
+use rango_types::{Checkpoint, Mutation, MutationOp, Revision};
+
+fn mutation_for(tenant_id: &str, namespace: &str, write_id: &str) -> Mutation {
+    let doc_id = rango_types::DocumentId::new_uuid_v7();
+    let rev = Revision::now("client-a");
+    Mutation {
+        op: MutationOp::Insert,
+        collection: "state".to_string(),
+        doc_id: doc_id.clone(),
+        patch: Some(doc! { "payload": write_id }),
+        seq: 0,
+        timestamp: bson::DateTime::now(),
+        rev: rev.clone(),
+        write_id: write_id.to_string(),
+        metadata: rango_types::MutationMetadata {
+            id: doc_id.clone(),
+            namespace: namespace.to_string(),
+            tenant_id: tenant_id.to_string(),
+            r#type: "state".to_string(),
+            rev,
+            created_at: bson::DateTime::now(),
+            updated_at: bson::DateTime::now(),
+            source: "client-a".to_string(),
+            actor: "client-a".to_string(),
+            lineage: doc_id.to_string(),
+            schema_version: 1,
+            trust_score: 0.95,
+            verified: Some(true),
+            expires_at: None,
+        },
+    }
+}
+
+#[tokio::test]
+async fn checkpoints_are_scoped_per_tenant_and_namespace() {
+    let oplog = Arc::new(FileOplog::new(temp_oplog_path()).unwrap());
+    let state = Arc::new(ServerState::new(oplog));
+    state.add_token_with_tenant("token-a", "client-a", "tenant-a");
+
+    let router = app(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    let client = SyncClient::new(format!("http://127.0.0.1:{port}"), "token-a");
+
+    let ns_a_push = client
+        .push_scoped(
+            "client-a",
+            "tenant-a",
+            "ns-a",
+            vec![mutation_for("tenant-a", "ns-a", "a-1")],
+            Checkpoint::initial(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(ns_a_push.accepted_seqs.len(), 1);
+
+    let ns_b_push = client
+        .push_scoped(
+            "client-a",
+            "tenant-a",
+            "ns-b",
+            vec![mutation_for("tenant-a", "ns-b", "b-1")],
+            Checkpoint::initial(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(ns_b_push.accepted_seqs.len(), 1);
+    assert!(
+        ns_b_push.new_checkpoint.0 > ns_a_push.new_checkpoint.0,
+        "ns-b should advance its own scope",
+    );
+
+    let node_mismatch_ns_a = client
+        .push_scoped(
+            "not-owner",
+            "tenant-a",
+            "ns-a",
+            Vec::new(),
+            Checkpoint::initial(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(node_mismatch_ns_a.rejected_non_owner_count, 1);
+    assert_eq!(
+        node_mismatch_ns_a.new_checkpoint.0,
+        ns_a_push.new_checkpoint.0,
+        "ns-a checkpoint must not jump due to ns-b activity on owner mismatch path",
+    );
+
+    let ns_a_pull = client
+        .pull_scoped("client-a", "tenant-a", "ns-a", Checkpoint::initial())
+        .await
+        .unwrap();
+    assert_eq!(ns_a_pull.mutations.len(), 1);
+}
+
+fn temp_oplog_path() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    std::env::temp_dir()
+        .join(format!("rango-checkpoint-scope-oplog-{}-{}.rgo", pid, n))
+        .to_string_lossy()
+        .to_string()
+}

--- a/crates/server/tests/checkpoint_scope.rs
+++ b/crates/server/tests/checkpoint_scope.rs
@@ -93,8 +93,7 @@ async fn checkpoints_are_scoped_per_tenant_and_namespace() {
         .unwrap();
     assert_eq!(node_mismatch_ns_a.rejected_non_owner_count, 1);
     assert_eq!(
-        node_mismatch_ns_a.new_checkpoint.0,
-        ns_a_push.new_checkpoint.0,
+        node_mismatch_ns_a.new_checkpoint.0, ns_a_push.new_checkpoint.0,
         "ns-a checkpoint must not jump due to ns-b activity on owner mismatch path",
     );
 


### PR DESCRIPTION
## Summary\n- compute 
ew_checkpoint from scoped oplog entries (	enant_id + 
amespace)\n- apply scoped checkpoint logic to push/pull/promote response paths\n- add regression test checkpoint_scope to ensure namespace activity does not advance unrelated scope checkpoints\n\n## Why\n- prevents cross-namespace activity leakage through checkpoint progression\n- tightens isolation guarantees for sync clients\n\n## Validation\n- cargo test -p rango-server --test checkpoint_scope\n- cargo test -p rango-server --test poisoning_leakage\n- cargo check -p rango-server\n\nRefs #10