### PR TITLE
docs(governance): branch-per-issue policy and clean architecture guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,30 @@ cargo deny check
 - **Offline-first** — any feature that requires network must degrade gracefully when offline
 - **No silent data loss** — errors must propagate; mutations must be durable before ack
 
+### Clean Architecture (Crate Layering)
+Dependencies flow inward only. Each crate has one reason to change.
+
+- `rango-types` — pure domain contracts (envelopes, mutation metadata, checkpoints). No I/O. No deps on other workspace crates.
+- `rango-core` — engine, control plane, deterministic apply/replay. Depends on `rango-types` only. Owns use-case orchestration; never imports infra crates directly.
+- `rango-storage`, `rango-oplog`, `rango-index`, `rango-query` — infrastructure adapters behind traits defined in `rango-types`/`rango-core`. Never depended on by `rango-core`.
+- `rango-sync`, `rango-server`, `rango-sdk-rust`, `rango-cli` — entrypoints (transport, ingress, public API, CLI). Compose core + adapters; never bypass them.
+
+Forbidden:
+- Reverse dependencies (e.g. `rango-core` importing `rango-storage`).
+- Domain types living outside `rango-types`.
+- Adapter-specific leakage in core APIs (no `redb::*`, `axum::*`, etc. in `rango-core` signatures).
+- Workflow/orchestration semantics in core.
+
+### Clean Code Rules
+- One responsibility per module. Split when a file holds two unrelated change reasons.
+- Functions: short, intent-named verbs. No flag arguments — split into two functions instead.
+- Types: nouns describing the concept, not the storage shape (`MutationBatch`, not `BatchStruct`).
+- No `unwrap`/`expect`/`panic!` outside tests and explicit invariants. Use typed errors with `thiserror`.
+- No global mutable state. Configuration is constructed at the entrypoint and injected.
+- Public API: minimal surface. Expose traits, not concrete types, when consumers depend on behavior.
+- Comments explain *why*, not *what*. Delete redundant comments; rename instead.
+- No dead code, no commented-out code, no TODOs without an issue link.
+
 ---
 
 ## Testing Requirements
@@ -170,12 +194,14 @@ Do not add task-level checklists to `ROADMAP.md`; keep those in issues.
 
 ## Submitting a Pull Request
 
-1. **Fork** the repository and create a feature branch from `main`
+1. **Pick or open an issue** before writing code — every change must be tracked.
+2. **Branch off `main`** using the convention `issue/<N>-<short-slug>`:
    ```bash
-   git checkout -b feat/my-feature
+   git checkout -b issue/35-pyo3-binding
    ```
-2. Make your changes following the standards above
-3. Ensure all checks pass locally:
+   One issue per branch. One PR per branch. Delete the branch after merge.
+3. Make your changes following the standards above. Rebase on `main` rather than merging when refreshing.
+4. Ensure all checks pass locally:
    ```bash
    cargo fmt --all
    cargo clippy --workspace --all-targets --all-features -- -D warnings

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,28 +83,52 @@ Success criteria:
 
 Deliver a usable and trustworthy integration baseline for external products.
 
+Workstream A — substrate closure:
 - canonical metadata enforcement end-to-end in write/read paths
 - policy enforcement in control-plane hooks (write/read/promotion)
 - snapshot/rollback deterministic recovery tests
 - tenant/namespace isolation hardening in sync/server paths
+
+Workstream B — external contract:
 - integration-ready SDK contract and onboarding path (OpenClaw + generic)
+- OpenClaw smoke integration running in CI on every PR
+- migration/upgrade guide v0.0 -> v0.1 with `rango doctor` upgrade checks
 
 ### v0.2.0 (Hardening Baseline)
 
-Make security/governance observable and production-safe.
+Make security/governance observable, production-safe, and adoptable from polyglot stacks.
 
+Workstream C — audit and observability:
 - audit trail completeness for memory operations
 - anomaly signals and containment hooks
-- poisoning regression suite and trust-aware safety tests
-- release-grade operational docs and upgrade guidance
+- OpenTelemetry metrics and tracing contract (hub + embedded)
+- health/readiness endpoints and structured logs in `rango-server`
+
+Workstream D — public trust moat:
+- adversarial benchmark suite (poisoning, cross-tenant leak, byte-exact replay)
+- public benchmark results + "Memory != Storage" thesis post
+- compliance posture document (audit, retention, isolation)
+
+Workstream E — polyglot DX:
+- Python binding via PyO3 (minimum SDK surface, wheels on 3 OSes)
+- TS/Node binding via napi-rs (parity with Python binding)
+- reference integration: LangGraph agent on Rango
+- reference integration: CrewAI agent on Rango
 
 ### v0.3.0 (Capabilities Baseline)
 
-Enable advanced retrieval capabilities without contaminating core truth.
+Enable advanced retrieval capabilities without contaminating core truth and harden multi-node operation.
 
+Workstream F — capability contracts:
 - external vector/graph capability contracts
-- bounded context assembly adapters with trust-aware ranking inputs
-- projection rebuild/invalidation toolchain hardening
+- adapter conformance kit (mock + golden fixtures)
+- reference adapters: pgvector, Qdrant
+- trust-aware ranking input contract + bounded context assembly docs
+
+Workstream G — operability:
+- backup/restore CLI with optional S3 sink
+- multi-node sync hardening (partition/heal regression suite)
+- Grafana reference dashboard wired to OTel metrics
 
 ## GitHub Execution Model
 

--- a/docs/operations/workflow.md
+++ b/docs/operations/workflow.md
@@ -21,6 +21,19 @@ This is the operational workflow for planning and execution in Rango.
 4. Move status through labels (`status:ready`, `status:in-progress`, `status:blocked`, `status:done`).
 5. Merge PR with `Closes #<issue>`.
 
+## Branching Policy
+
+All work happens on a dedicated branch tied to an issue. No direct commits to `main`.
+
+- Branch name: `issue/<N>-<short-slug>` (e.g. `issue/35-pyo3-binding`).
+- Branch off `main`. Rebase rather than merge from `main` when refreshing.
+- One issue per branch. If scope grows, split into a follow-up issue and branch.
+- One PR per branch. PR title mirrors the conventional commit type and references the issue (`Closes #N`).
+- Delete the branch after merge.
+- Hotfixes follow the same flow against an `area:*` issue with `priority:p0`.
+
+A branch without a tracking issue is rejected at review.
+
 ## Required Fields for New Work
 
 Every issue must include:
@@ -86,6 +99,10 @@ CODEOWNERS is defined in `.github/CODEOWNERS` to formalize ownership on critical
   - `area:sdk`
   - `area:cli`
   - `area:docs`
+  - `area:bindings`
+  - `area:bench`
+  - `area:integrations`
+  - `area:observability`
 
 ## Cadence
 


### PR DESCRIPTION
## Summary
- Adopt `issue/<N>-<slug>` branching convention; one issue per branch, one PR per branch.
- Document Clean Architecture (crate layering, forbidden reverse dependencies) and Clean Code rules in `CONTRIBUTING.md`.
- Register new area labels (`area:bindings`, `area:bench`, `area:integrations`, `area:observability`) in `docs/operations/workflow.md`.
- Surface the v0.1 / v0.2 / v0.3 workstream breakdown in `ROADMAP.md` so it matches the GitHub milestones.

## Why
We just expanded the GitHub roadmap (24 open issues across three milestones). Without a documented branching and architecture discipline, scope and crate boundaries drift. This PR locks the rules in writing so every contributor follows the same shape.

## Closes
Closes #40

## Test plan
- [ ] CI: docs job, formatting, link checks pass
- [ ] Maintainer review of policy wording
- [ ] First downstream PR uses `issue/<N>-<slug>` and the documented Clean Architecture rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)