### PR TITLE
fix(server): clear pre-existing clippy errors in routes.rs

### DIFF
--- a/crates/server/src/routes.rs
+++ b/crates/server/src/routes.rs
@@ -24,6 +24,10 @@ use tracing::{info, instrument};
 
 use crate::retrieval::{RetrievalRuntime, ranking::rank_candidates_v1};
 
+// Type aliases for scoped index maps
+type ScopedLatestCheckpointIndex = HashMap<(String, String), u64>;
+type ScopedWriteIdIndex = HashMap<(String, String, String), u64>;
+
 #[derive(Debug, Clone)]
 pub struct AuthPrincipal {
     pub node_id: String,
@@ -569,7 +573,7 @@ impl ServerState {
         }
 
         let payload = WritePayload::StateWithTrust {
-            document: req.mutation.patch.clone().unwrap_or_else(Document::new),
+            document: req.mutation.patch.clone().unwrap_or_default(),
             trust_score: req.mutation.metadata.trust_score,
         };
 
@@ -623,12 +627,7 @@ fn scoped_latest_checkpoint(
     Ok(Checkpoint(scoped_latest))
 }
 
-fn build_scoped_indexes(
-    oplog: &dyn Oplog,
-) -> (
-    HashMap<(String, String), u64>,
-    HashMap<(String, String, String), u64>,
-) {
+fn build_scoped_indexes(oplog: &dyn Oplog) -> (ScopedLatestCheckpointIndex, ScopedWriteIdIndex) {
     let mut scoped_latest = HashMap::new();
     let mut scoped_write_ids = HashMap::new();
 


### PR DESCRIPTION
## Summary
- `crates/server/src/routes.rs:576` — replace `unwrap_or_else(Document::new)` with `unwrap_or_default()` (clippy::unwrap_or_default).
- `crates/server/src/routes.rs:630` — extract two type aliases (`ScopedLatestCheckpointIndex`, `ScopedWriteIdIndex`) for the two-map return tuple to satisfy `clippy::type_complexity`.

## Why
With these two pre-existing errors gone, `cargo clippy --workspace --all-targets --all-features -- -D warnings` now exits 0 across the entire workspace. That unlocks adding the strict flag to CI later (separate change) and removes a long-standing distraction from every other PR.

## Closes
Closes #43

## Test plan
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — green
- [x] `cargo test -p rango-server` — green
- [x] `cargo build --workspace` — green
- [x] `cargo fmt --all -- --check` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)