### PR TITLE
refactor: erase StorageEngine generic from RangoClient and RangoEngine

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -636,10 +636,7 @@ fn run_doctor(path: &Path, passphrase: Option<&str>) -> Result<()> {
     }
 }
 
-fn check_canonical_envelope_metadata(
-    client: &rango_sdk::RangoClient,
-    report: &mut DoctorReport,
-) {
+fn check_canonical_envelope_metadata(client: &rango_sdk::RangoClient, report: &mut DoctorReport) {
     use rango_types::CollectionName;
 
     // We need to sample from existing collections. For MVP, we try a few common collection names

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -637,7 +637,7 @@ fn run_doctor(path: &Path, passphrase: Option<&str>) -> Result<()> {
 }
 
 fn check_canonical_envelope_metadata(
-    client: &rango_sdk::RangoClient<rango_storage::RedbStorage>,
+    client: &rango_sdk::RangoClient,
     report: &mut DoctorReport,
 ) {
     use rango_types::CollectionName;
@@ -746,7 +746,7 @@ fn open_persistent_client(
     path: &Path,
     node_id: &str,
     passphrase: Option<&str>,
-) -> Result<rango_sdk::RangoClient<rango_storage::RedbStorage>, anyhow::Error> {
+) -> Result<rango_sdk::RangoClient, anyhow::Error> {
     let config = load_config(path);
     let storage = Arc::new(rango_storage::RedbStorage::open(path.join("data.redb"))?);
     let crypto = load_crypto(path, passphrase)?;

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -11,8 +11,8 @@ use tracing::{info, instrument, warn};
 use crate::metrics::Metrics;
 
 /// The main Rango engine — coordinates storage, indexing, query, and sync.
-pub struct RangoEngine<S: StorageEngine> {
-    storage: Arc<S>,
+pub struct RangoEngine {
+    storage: Arc<dyn StorageEngine>,
     oplog: Arc<dyn Oplog>,
     node_id: String,
     metrics: Metrics,
@@ -20,9 +20,9 @@ pub struct RangoEngine<S: StorageEngine> {
     applied_write_ids: Mutex<HashSet<String>>,
 }
 
-impl<S: StorageEngine> RangoEngine<S> {
+impl RangoEngine {
     pub fn open(
-        storage: Arc<S>,
+        storage: Arc<dyn StorageEngine>,
         oplog: Arc<dyn Oplog>,
         node_id: impl Into<String>,
     ) -> Result<Self, RangoError> {
@@ -30,7 +30,7 @@ impl<S: StorageEngine> RangoEngine<S> {
     }
 
     pub fn open_with_config(
-        storage: Arc<S>,
+        storage: Arc<dyn StorageEngine>,
         oplog: Arc<dyn Oplog>,
         node_id: impl Into<String>,
         config: RangoConfig,

--- a/crates/core/tests/crud_tests.rs
+++ b/crates/core/tests/crud_tests.rs
@@ -6,7 +6,7 @@ use rango_oplog::NullOplog;
 use rango_storage::MemoryStorage;
 use rango_types::{CollectionName, DocumentId};
 
-fn setup() -> RangoEngine<MemoryStorage> {
+fn setup() -> RangoEngine {
     let storage = Arc::new(MemoryStorage::new());
     let oplog = Arc::new(NullOplog::new());
     RangoEngine::open(storage, oplog, "test-node").unwrap()

--- a/crates/core/tests/query_tests.rs
+++ b/crates/core/tests/query_tests.rs
@@ -6,7 +6,7 @@ use rango_oplog::NullOplog;
 use rango_storage::MemoryStorage;
 use rango_types::CollectionName;
 
-fn setup() -> RangoEngine<MemoryStorage> {
+fn setup() -> RangoEngine {
     let storage = Arc::new(MemoryStorage::new());
     let oplog = Arc::new(NullOplog::new());
     RangoEngine::open(storage, oplog, "test-node").unwrap()

--- a/crates/core/tests/recovery_tests.rs
+++ b/crates/core/tests/recovery_tests.rs
@@ -7,7 +7,7 @@ use rango_oplog::{FileOplog, NullOplog};
 use rango_storage::{MemoryStorage, RedbStorage};
 use rango_types::{CollectionName, DocumentId, Mutation, MutationOp, Revision};
 
-fn setup_memory(node_id: &str) -> RangoEngine<MemoryStorage> {
+fn setup_memory(node_id: &str) -> RangoEngine {
     let storage = Arc::new(MemoryStorage::new());
     let oplog = Arc::new(NullOplog::new());
     RangoEngine::open(storage, oplog, node_id).unwrap()

--- a/crates/core/tests/rollback_tests.rs
+++ b/crates/core/tests/rollback_tests.rs
@@ -8,7 +8,7 @@ use rango_types::{
     CollectionName, DocumentId, Mutation, MutationOp, PolicyDecision, Revision, RollbackUnit,
 };
 
-fn setup(node_id: &str) -> RangoEngine<MemoryStorage> {
+fn setup(node_id: &str) -> RangoEngine {
     let storage = Arc::new(MemoryStorage::new());
     let oplog = Arc::new(NullOplog::new());
     RangoEngine::open(storage, oplog, node_id).unwrap()

--- a/crates/core/tests/semantic_rebuild_invalidation.rs
+++ b/crates/core/tests/semantic_rebuild_invalidation.rs
@@ -6,7 +6,7 @@ use rango_oplog::NullOplog;
 use rango_storage::MemoryStorage;
 use rango_types::{CollectionName, MemoryTier};
 
-fn setup(node_id: &str) -> RangoEngine<MemoryStorage> {
+fn setup(node_id: &str) -> RangoEngine {
     let storage = Arc::new(MemoryStorage::new());
     let oplog = Arc::new(NullOplog::new());
     RangoEngine::open(storage, oplog, node_id).unwrap()

--- a/crates/core/tests/sync_tests.rs
+++ b/crates/core/tests/sync_tests.rs
@@ -16,7 +16,7 @@ use rango_types::{
 };
 use std::str::FromStr;
 
-fn setup(node_id: &str) -> RangoEngine<MemoryStorage> {
+fn setup(node_id: &str) -> RangoEngine {
     let storage = Arc::new(MemoryStorage::new());
     let oplog = Arc::new(NullOplog::new());
     RangoEngine::open(storage, oplog, node_id).unwrap()

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -65,7 +65,7 @@ fn rango_err_to_napi(err: RangoError) -> Error {
 
 #[napi]
 pub struct RangoClient {
-    client: rango_sdk::RangoClient<DegradingStorage<RedbStorage>>,
+    client: rango_sdk::RangoClient,
 }
 
 #[napi]

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -80,7 +80,7 @@ fn parse_doc_id(id: &str) -> DocumentId {
 /// ```
 #[pyclass(name = "RangoClient")]
 pub struct PyRangoClient {
-    client: rango_sdk::RangoClient<DegradingStorage<RedbStorage>>,
+    client: rango_sdk::RangoClient,
 }
 
 #[pymethods]

--- a/crates/sdk-rust/src/client.rs
+++ b/crates/sdk-rust/src/client.rs
@@ -7,14 +7,14 @@ use std::sync::Arc;
 use tracing::instrument;
 
 /// Public SDK for Rango.
-pub struct RangoClient<S: StorageEngine> {
-    engine: RangoEngine<S>,
+pub struct RangoClient {
+    engine: RangoEngine,
 }
 
-impl<S: StorageEngine> RangoClient<S> {
+impl RangoClient {
     #[instrument(skip(storage, oplog, node_id))]
     pub fn open(
-        storage: Arc<S>,
+        storage: Arc<dyn StorageEngine>,
         oplog: Arc<dyn Oplog>,
         node_id: impl Into<String>,
     ) -> Result<Self, RangoError> {
@@ -26,7 +26,7 @@ impl<S: StorageEngine> RangoClient<S> {
     #[doc(hidden)]
     #[instrument(skip(storage, oplog, node_id, config))]
     pub fn open_with_config(
-        storage: Arc<S>,
+        storage: Arc<dyn StorageEngine>,
         oplog: Arc<dyn Oplog>,
         node_id: impl Into<String>,
         config: RangoConfig,
@@ -36,7 +36,7 @@ impl<S: StorageEngine> RangoClient<S> {
         })
     }
 
-    pub fn collection(&self, name: &str) -> CollectionClient<'_, S> {
+    pub fn collection(&self, name: &str) -> CollectionClient<'_> {
         CollectionClient {
             client: self,
             name: CollectionName::new(name),
@@ -47,17 +47,17 @@ impl<S: StorageEngine> RangoClient<S> {
     /// This is a temporary escape hatch for code not yet migrated to the stable SDK surface.
     /// Do not build new code on this method; it may be removed in a future release.
     #[doc(hidden)]
-    pub fn __engine(&self) -> &RangoEngine<S> {
+    pub fn __engine(&self) -> &RangoEngine {
         &self.engine
     }
 }
 
-pub struct CollectionClient<'a, S: StorageEngine> {
-    client: &'a RangoClient<S>,
+pub struct CollectionClient<'a> {
+    client: &'a RangoClient,
     name: CollectionName,
 }
 
-impl<S: StorageEngine> CollectionClient<'_, S> {
+impl CollectionClient<'_> {
     #[instrument(skip(self, doc), fields(collection = %self.name.0))]
     pub fn insert_one(&self, doc: Document) -> Result<DocumentId, RangoError> {
         self.client.engine.insert_one(&self.name, doc)

--- a/crates/sdk-rust/src/migrate.rs
+++ b/crates/sdk-rust/src/migrate.rs
@@ -3,7 +3,6 @@ use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::Path;
 
 use bson::Document;
-use rango_storage::StorageEngine;
 use rango_types::{CollectionName, RangoError};
 
 use crate::RangoClient;
@@ -54,7 +53,7 @@ pub struct ExportResult {
     pub exported: usize,
 }
 
-impl<S: StorageEngine> RangoClient<S> {
+impl RangoClient {
     /// Import documents from a JSON Lines file (one JSON document per line).
     /// Each line should be a valid JSON object. If the object has an `_id` field,
     /// it will be preserved (ObjectId strings are converted to BSON ObjectId).
@@ -335,7 +334,7 @@ mod tests {
     use std::sync::Arc;
     use tempfile::NamedTempFile;
 
-    fn create_test_client() -> RangoClient<rango_storage::MemoryStorage> {
+    fn create_test_client() -> RangoClient {
         let storage = Arc::new(rango_storage::MemoryStorage::new());
         let oplog = Arc::new(rango_oplog::NullOplog::new());
         RangoClient::open(storage, oplog, "test-node").unwrap()

--- a/docs/reference/sdk-stability.md
+++ b/docs/reference/sdk-stability.md
@@ -23,7 +23,7 @@ The following items are **stable** and subject to SemVer compatibility guarantee
 ### RangoClient Methods
 
 - `RangoClient::open(storage, oplog, node_id) -> Result<Self, RangoError>`
-- `RangoClient::collection(name) -> CollectionClient<'_, S>`
+- `RangoClient::collection(name) -> CollectionClient<'_>`
 - `RangoClient::import_json(collection, path, progress) -> Result<ImportResult, RangoError>`
 - `RangoClient::export_json(collection, path) -> Result<ExportResult, RangoError>`
 
@@ -135,17 +135,17 @@ If your change causes `examples/sdk-stability/` to fail compilation, it is a bre
 
 ---
 
-## Known Limitation: Generic StorageEngine
+## Type Erasure
 
-The SDK is currently generic over `StorageEngine`:
+The SDK uses type erasure for storage engines:
 
 ```rust
-pub struct RangoClient<S: StorageEngine> { /* ... */ }
+pub struct RangoClient { /* ... */ }
 ```
 
-This means users must link against a concrete storage adapter (e.g., `RedbStorage` from `rango-storage`) when building applications. Type erasure to `Box<dyn StorageEngine>` is intentionally deferred to a follow-up issue with its own ADR.
+Storage engines are passed as `Arc<dyn StorageEngine>` at construction time. This allows users to swap storage backends at runtime without changing client code.
 
-**Implication**: Users cannot freely swap storage backends at runtime in v0.1.0. This is a known constraint and will be revisited in a future release.
+**Implication**: Users can freely use any `StorageEngine` implementation (e.g., `RedbStorage`, `MemoryStorage`) without generic parameter propagation in their application code.
 
 ---
 

--- a/examples/stateful_agent_wedge.rs
+++ b/examples/stateful_agent_wedge.rs
@@ -113,7 +113,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn open_client(node_id: &str) -> Result<RangoClient<MemoryStorage>, Box<dyn std::error::Error>> {
+fn open_client(node_id: &str) -> Result<RangoClient, Box<dyn std::error::Error>> {
     let storage = Arc::new(MemoryStorage::new());
     let oplog = Arc::new(NullOplog::new());
     Ok(RangoClient::open(storage, oplog, node_id)?)


### PR DESCRIPTION
Closes #44

## Summary
- Remove StorageEngine generic parameter from RangoEngine (Arc<S> → Arc<dyn StorageEngine>)
- Remove StorageEngine generic parameter from RangoClient and CollectionClient
- Update all downstream consumers: CLI, Python binding, Node binding
- Update core tests to use erased types
- Update sdk-stability documentation to reflect type erasure

## Test Plan
- [x] cargo check --workspace --all-targets passes
- [x] cargo test --workspace passes
- [x] cargo clippy --workspace --all-targets passes