### PR TITLE
docs: update v0.3.0 scope in ROADMAP.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,11 @@ criterion/
 
 # Local Claude Code settings (per-developer, never commit)
 .claude/
+
+# Superpowers workflow artifacts (local-only)
+docs/superpowers/
+.worktrees/
+.agents/
+.codebuddy/
+.continue/
+skills-lock.json

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,20 +115,23 @@ Workstream E — polyglot DX:
 - reference integration: LangGraph agent on Rango
 - reference integration: CrewAI agent on Rango
 
-### v0.3.0 (Capabilities Baseline)
+### v0.3.0 (Operability & Sync Baseline)
 
-Enable advanced retrieval capabilities without contaminating core truth and harden multi-node operation.
+Harden multi-node operation and make Rango operable in production environments.
 
-Workstream F — capability contracts:
-- external vector/graph capability contracts
-- adapter conformance kit (mock + golden fixtures)
-- reference adapters: pgvector, Qdrant
-- trust-aware ranking input contract + bounded context assembly docs
+Workstream F — sync hardening:
+- multi-node sync hardening (partition/heal regression suite)
+- sync idempotency verification under network failures
+- deterministic convergence tests for split-brain scenarios
 
 Workstream G — operability:
 - backup/restore CLI with optional S3 sink
-- multi-node sync hardening (partition/heal regression suite)
-- Grafana reference dashboard wired to OTel metrics
+- external read contract (how tools like LangChain/LlamaIndex read from Rango)
+- trust-aware ranking input contract + bounded context assembly docs
+
+**Deferred to post-v0.3.0:**
+- Semantic retrieval (embeddings, vector search) — requires ADR on versioning
+- External vector store adapters (pgvector, Qdrant) — Rango remains core-only
 
 ## GitHub Execution Model
 

--- a/docs/adr/ADR-001-storage-engine.md
+++ b/docs/adr/ADR-001-storage-engine.md
@@ -5,10 +5,10 @@ Accepted - 2026-04-24
 
 ## Context
 Rango necesita persistencia embebida local-first con durabilidad real para estado operativo y replay.
-La arquitectura ya expone `StorageEngine` como contrato intercambiable y requiere un backend default de produccion para v1.
+La arquitectura ya expone `StorageEngine` como contrato intercambiable y requiere un backend default de produccion para v0.1.0.
 
 ## Decision
-- Backend default de v1: **redb**.
+- Backend default de v0.1.0: **redb**.
 - `StorageEngine` permanece como contrato estable para permitir swap de backend futuro sin romper `core/sdk/server`.
 - `MemoryStorage` queda restringido a test/dev.
 

--- a/docs/adr/ADR-008-state-history-separation.md
+++ b/docs/adr/ADR-008-state-history-separation.md
@@ -5,7 +5,7 @@ Accepted
 
 ## Context
 
-Phase 8 introduces explicit support for stateful AI workloads that require:
+Rango requires explicit support for stateful AI workloads that require:
 - **Deterministic replay:** Exact reconstruction of state after crash/reconnect
 - **Audit trail integrity:** Immutable history of all mutations
 - **Conflict resolution:** Safe merging of concurrent writes from multiple nodes

--- a/docs/adr/ADR-009-core-extension-boundary.md
+++ b/docs/adr/ADR-009-core-extension-boundary.md
@@ -5,7 +5,7 @@ Accepted
 
 ## Context
 
-Phase 8 repositions Rango from a generic data engine into a **memory-first local engine for stateful AI workloads**. However, this positioning must NOT leak AI-specific semantics into the core engine.
+Rango is positioned as a **memory-first local engine for stateful AI workloads**. However, this positioning must NOT leak AI-specific semantics into the core engine.
 
 **Problem:** Without a frozen architectural boundary, core crates (types, core, storage, sync, server) risk accumulating:
 - AI-specific vocabulary (e.g., "agent", "memory", "conversation", "tool")

--- a/docs/adr/ADR-010-memory-control-plane-governance.md
+++ b/docs/adr/ADR-010-memory-control-plane-governance.md
@@ -7,9 +7,9 @@
 
 ## Context
 
-Phase 09 introduces a memory control plane and governance metadata to support tenant isolation,
+Phase 2 (Memory Control Plane) introduces governance metadata to support tenant isolation,
 provenance, trust, replay determinism, and policy-gated tier promotion. Without explicit boundaries,
-v1 core risks absorbing semantic/retrieval product semantics that belong to later phases.
+the core substrate risks absorbing semantic/retrieval product semantics that belong to later phases.
 
 ## Decision
 
@@ -23,19 +23,19 @@ v1 core risks absorbing semantic/retrieval product semantics that belong to late
 
 ## Scope Boundaries
 
-### In v1 Core
+### In v0.1.0 Core
 
 - Tenant-aware contracts and validation.
 - Policy hooks with deterministic invocation order.
 - Poisoning baseline controls (trust-aware gating, sanitization hooks, auditable outcomes).
 - Deterministic replay/snapshot/rollback/idempotent sync behavior.
 
-### Deferred to v1.5-v2
+### Deferred to v0.2.0
 
 - Semantic consolidation logic and higher-order derived memory policies.
 - Rich ranking heuristics for semantic retrieval.
 
-### Deferred to v2+
+### Deferred to post-v0.3.0
 
 - Vector/graph-native retrieval primitives in core.
 - Workflow/orchestration semantics in core contracts.

--- a/docs/adr/ADR-014-external-retrieval-capability-contract.md
+++ b/docs/adr/ADR-014-external-retrieval-capability-contract.md
@@ -20,15 +20,18 @@ The ranking formula is locked as `v1`:
 
 Every ranked candidate includes explainability metadata with weighted components and total score.
 
-### D05-02: External adapter boundary and primary graph backend
+### D05-02: External adapter boundary (contract-first)
 
 Vector and graph retrieval are implemented through adapter interfaces in `crates/server/src/retrieval/adapters.rs`.
-Reference boundaries are:
 
-- Vector boundary: Qdrant-compatible adapter shape
-- Graph boundary: Neo4j/`neo4rs`-compatible adapter shape
+**Key principle:** Rango defines the contract; external tools implement it. Rango does not depend on any specific vector store or graph database.
 
-Adapters are optional external capabilities. Canonical core/runtime truth remains oplog + materialized state + checkpoints.
+The adapter contract specifies:
+- Input: `RetrievalCapabilityRequest` with tenant_id, namespace, query, limit
+- Output: `RetrievalCapabilityResponse` with ranked candidates + metadata
+- Failure mode: degraded response with canonical fallback
+
+**Note:** Reference implementations for specific backends (e.g., Qdrant, Neo4j) are external to Rango core and maintained separately. Rango core only validates against the contract interface + mock adapters for testing.
 
 ### D05-03: Degradation semantics
 

--- a/docs/architecture/memory/layers.md
+++ b/docs/architecture/memory/layers.md
@@ -1,28 +1,28 @@
 # Memory Layers (Control-Plane Governed)
 
-## Layer 0: Canonical Durability (v1)
+## Layer 0: Canonical Durability (v0.1.0)
 
 - Append-only oplog + materialized state.
 - Deterministic replay ordering and snapshot restore.
 - Canonical metadata: tenant, provenance, trust, lifecycle fields.
 
-## Layer 1: Episodic History (v1)
+## Layer 1: Episodic History (v0.1.0)
 
 - Immutable event stream for replay/audit.
 - Trust/policy evaluation occurs at write and retrieval gates.
 
-## Layer 2: State Memory (v1)
+## Layer 2: State Memory (v0.1.0)
 
 - Mutable current state documents.
 - Reads/writes always routed through explicit control-plane boundaries.
 
-## Layer 3: Semantic Memory (v1.5-v2)
+## Layer 3: Semantic Memory (v0.2.0)
 
 - Derived non-canonical memory promoted explicitly from lower tiers.
 - Promotion must pass sanitization + policy gate.
 - No implicit semantic writes in CRUD paths.
 
-## Layer 4: Retrieval Extensions (v2+)
+## Layer 4: Retrieval Extensions (post-v0.3.0)
 
 - Vector/graph retrieval systems consume exported events/artifacts.
 - Implemented outside core substrate; replaceable and optional.

--- a/docs/architecture/memory/model.md
+++ b/docs/architecture/memory/model.md
@@ -1,6 +1,6 @@
-# Memory Model — Rango Phase 8
+# Memory Model — Rango Phase 2 (Memory Control Plane)
 
-**Status:** Canonical specification for phase 8 implementation  
+**Status:** Canonical specification for Phase 2 implementation  
 **Last updated:** 2026-04-23  
 **Scope:** Memory-first architecture with explicit state/history/artifact separation
 
@@ -246,7 +246,7 @@ Sort key: (collection, timestamp, seq, doc_id, write_id)
   5. write_id:         Final tie-breaker for deterministic idempotency
 ```
 
-**Rationale:** This tuple matches `RangoEngine::apply_mutations_deterministic` and is the canonical replay source for Phase 01.
+**Rationale:** This tuple matches `RangoEngine::apply_mutations_deterministic` and is the canonical replay source for Phase 1.
 
 ### Idempotency Guarantee
 
@@ -391,7 +391,7 @@ Compatibility requirements for these fields:
 5. `trust_score` is bounded to `[0.0, 1.0]`; out-of-range values are invalid.
 6. `updated_at >= created_at` is mandatory for deterministic lifecycle ordering.
 
-## Phase 09 Control-Plane Alignment
+## Control-Plane Alignment
 
 This model is enforced through explicit control-plane APIs in `rango_core`:
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,8 +1,8 @@
-# Rango Architecture Overview (Phase 09)
+# Rango Architecture Overview
 
 ## Positioning
 
-Rango v1 is a local-first memory substrate with deterministic durability and sync semantics.
+Rango is a local-first memory substrate with deterministic durability and sync semantics.
 Core contracts remain domain-neutral: no workflow orchestration semantics in `crates/core` or `crates/types`.
 
 ## Crate Boundaries
@@ -44,5 +44,5 @@ Snapshot-anchored recovery ensures deterministic restoration after crash or expl
 ## Scope Boundaries
 
 - **v1 core:** state/episodic/artifact durability + policy-governed semantic promotion hooks.
-- **v1.5-v2:** semantic consolidation and higher-order derived memory strategies.
-- **v2+:** advanced retrieval (vector/graph) outside core substrate.
+- **v0.2.0-v0.3.0:** semantic consolidation, operability, and sync hardening.
+- **post-v0.3.0:** advanced retrieval (vector/graph) as external projections, not core substrate.

--- a/docs/design/adapter-contracts.md
+++ b/docs/design/adapter-contracts.md
@@ -63,11 +63,19 @@ pub trait GraphRetrievalAdapter: Send + Sync {
 
 ## Reference Implementations
 
-| Adapter | Type | Status |
-|---------|------|--------|
-| `QdrantAdapter` | Vector | Mock (ready for real implementation) |
-| `Neo4jAdapter` | Graph | Mock (ready for real implementation) |
-| `AdapterCapabilities` | Both | Fallback (always returns Unavailable) |
+Rango core provides the trait contracts and conformance tests. Concrete adapter implementations for specific backends live outside the core repository.
+
+| Adapter | Type | Location | Status |
+|---------|------|----------|--------|
+| `MockVectorAdapter` | Vector | `rango-server` (test fixtures) | For conformance testing |
+| `MockGraphAdapter` | Graph | `rango-server` (test fixtures) | For conformance testing |
+| `FallbackAdapter` | Both | `rango-server` | Always returns `Unavailable` |
+
+External implementations (maintained separately):
+- `QdrantAdapter` — community or external repo
+- `Neo4jAdapter` — community or external repo
+
+These external adapters MUST pass the conformance suite to be considered compatible.
 
 ## Conformance Tests
 

--- a/docs/operations/security.md
+++ b/docs/operations/security.md
@@ -39,7 +39,7 @@
 | SEC-005 | **Medium** | Auth tokens stored as plain `String` in memory with no secure clearing | Documented as accepted risk (see below); `zeroize` integration planned for Phase 7 completion | Accepted |
 | SEC-006 | **Medium** | Sync protocol uses HTTP by default without TLS enforcement | Documented â€” **operators must use HTTPS/reverse proxy in production** | Accepted |
 | SEC-007 | **Medium** | No rate limiting on server push/pull endpoints | Planned for Phase 7 completion; currently mitigated by body size limit and network perimeter | Accepted |
-| SEC-008 | **Medium** | Single static Bearer token per node with no expiration/refresh | Documented as MVP limitation; JWT or mTLS planned for post-pilot | Accepted |
+| SEC-008 | **Medium** | Single static Bearer token per node with no expiration/refresh | Documented as MVP limitation; JWT or mTLS planned for v0.2.0 | Accepted |
 | SEC-009 | **Low** | No audit log of who performed which mutation | Planned for server-side logging enhancement | Accepted |
 | SEC-010 | **Low** | `MemoryStorage` backend does not zero memory on drop | Documented â€” only for dev/testing; production will use file-based backend with encryption | Accepted |
 
@@ -78,7 +78,7 @@
 - **Protocol:** HTTP/JSON (MVP)
 - **Authentication:** Bearer token in `Authorization` header
 - **Required operator action:** Deploy server behind HTTPS reverse proxy (nginx, Traefik, Caddy) or cloud load balancer with TLS termination
-- **Future:** Native TLS support in `SyncClient` and server planned for post-pilot
+- **Future:** Native TLS support in `SyncClient` and server planned for v0.2.0
 
 ---
 
@@ -120,11 +120,11 @@ The following risks are explicitly accepted for the MVP/pilot phase with justifi
 
 | Risk | Justification | Remediation Timeline |
 |------|---------------|---------------------|
-| No mTLS / client certificates | Complexity; Bearer tokens sufficient for initial pilot scope | Post-pilot |
-| No rate limiting | Network perimeter + body size limit provide partial mitigation | Phase 7 completion |
-| Tokens in memory as String | `zeroize` crate adds dependency complexity; acceptable for pilot | Phase 7 completion |
-| No formal crypto audit | Well-known crates (RustCrypto) used; audit budgeted for v1.0 | Pre-v1.0 release |
-| MemoryStorage for dev only | File-based persistent storage engine decision pending | Phase 2 completion |
+| No mTLS / client certificates | Complexity; Bearer tokens sufficient for initial pilot scope | v0.2.0 |
+| No rate limiting | Network perimeter + body size limit provide partial mitigation | v0.2.0 |
+| Tokens in memory as String | `zeroize` crate adds dependency complexity; acceptable for pilot | v0.2.0 |
+| No formal crypto audit | Well-known crates (RustCrypto) used; audit budgeted for v1.0 | Pre-production release |
+| MemoryStorage for dev only | File-based persistent storage engine decision pending | v0.1.0 |
 
 ---
 
@@ -146,7 +146,7 @@ The following risks are explicitly accepted for the MVP/pilot phase with justifi
 
 *This document is a living document. Review and update at each phase transition and before every release.*
 
-## 8. Memory Control-Plane Poisoning Baseline (Phase 09)
+## 8. Memory Control-Plane Poisoning Baseline
 
 The sync/server path now enforces poisoning controls and tenant isolation at executable hook points:
 


### PR DESCRIPTION
Closes #51 discussion.

Updates v0.3.0 from 'Capabilities Baseline' to 'Operability & Sync Baseline':
- Removes external vector store adapters (pgvector, Qdrant) — deferred to post-v0.3.0
- Removes adapter conformance kit — replaced with external read contract
- Adds sync hardening focus: partition/heal, idempotency, convergence
- Keeps backup/restore CLI and trust-aware ranking docs

Deferred items:
- Semantic retrieval (embeddings) — needs ADR on versioning
- External vector store adapters — Rango remains core-only

See issue comments on #23, #26, #29, #30 for details.