### PR TITLE
docs: update CHANGELOG and README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **StorageEngine generic erased** (#44): `RangoClient` and `RangoEngine` are no longer generic over `StorageEngine`. The SDK surface is simpler: `RangoClient::open(Arc<dyn StorageEngine>, ...)` instead of `RangoClient<RedbStorage>`.
+- **ROADMAP v0.3.0 redefined** (#51, #53): v0.3.0 scope narrowed from "Capabilities Baseline" (vector/graph adapters) to "Operability & Sync Baseline". Semantic retrieval and external vector store adapters deferred to post-v0.3.0 pending an ADR on embedding versioning.
+
+### Documentation
+- Aligned outdated phase/version references across all docs: Phase 8/9 → current phases, v1/v1.5-v2/v2+ → v0.1.0/v0.2.0/post-v0.3.0.
+- Clarified that adapter contracts (vector/graph) define the interface only; concrete implementations (Qdrant, Neo4j) are external to core.
+
 ## [0.2.0] — 2026-04-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,21 +13,36 @@ Rango is built as infrastructure below agents and apps:
 - local-first writes with incremental sync
 - clear layer boundaries for future semantic/retrieval projections
 
-## v1 Scope
+## Version Scope
 
-Included in v1:
+### v0.1.0 — Durable Substrate
 
-- embedded local engine
-- append-only oplog
-- current state store
-- simple indexes and deterministic replay
-- snapshots/checkpoints
+- embedded local engine with `redb` backend
+- append-only oplog + deterministic replay
+- current state store with snapshots/checkpoints
+- simple B-tree indexes
 - sync foundations (push/pull + checkpoint progression)
 - tenant/namespace isolation primitives
 
-Out of v1 core:
+### v0.2.0 — Security & Governance
 
-- vector-native retrieval
+- audit trail completeness (`__governance_audit`)
+- anomaly detection + containment gates
+- graceful degradation (`DegradingStorage`)
+- OpenTelemetry metrics + health endpoints
+- Python (PyO3) and TypeScript/Node.js (napi-rs) bindings
+- adversarial benchmarks + CLI audit report
+
+### v0.3.0 — Operability & Sync (in progress)
+
+- multi-node sync hardening (partition/heal regression suite)
+- backup/restore CLI with optional S3 sink
+- external read contract (how tools read from Rango)
+- trust-aware ranking input contract documentation
+
+Out of core (post-v0.3.0):
+
+- vector-native retrieval (requires ADR on embedding versioning)
 - graph reasoning engine
 - workflow/orchestration semantics
 - dynamic plugin loading in core
@@ -121,11 +136,17 @@ rango sync ./memory --server http://localhost:8080 --token dev-token --node-id n
 
 ## Integration Modes for Products Built on Rango
 
-1. Embedded mode: each product instance embeds Rango locally for offline durability.
-2. Hub-and-spoke mode: product instances sync to a central `rango-server` hub.
-3. Multi-product mode: each product gets tenant/namespace isolation and shared sync topology.
+1. **Embedded mode**: each product instance embeds Rango locally for offline durability.
+2. **Hub-and-spoke mode**: product instances sync to a central `rango-server` hub.
+3. **Multi-product mode**: each product gets tenant/namespace isolation and shared sync topology.
 
 This allows products other than OpenClaw to use the same substrate with the same core contract.
+
+## Language Bindings
+
+- **Rust**: `rango-sdk` (native crate)
+- **Python**: `pip install rango` (PyO3 + maturin, see `crates/python/`)
+- **TypeScript/Node.js**: `npm install rango` (napi-rs, see `crates/node/`)
 
 ## Integrations
 
@@ -134,11 +155,20 @@ This allows products other than OpenClaw to use the same substrate with the same
 
 ## Release Naming
 
-- Stable tags: `vX.Y.Z` -> GitHub release name `Rango vX.Y.Z`
-- Main prereleases: `vX.Y.Z-rango-YYYYMMDD-HHMM-SHA` -> GitHub release name `Rango vX.Y.Z-rango.YYYYMMDD-HHMM+SHA`
-- Channel tags:
+- **Stable tags**: `vX.Y.Z` → GitHub release name `Rango vX.Y.Z`
+- **Main prereleases**: `vX.Y.Z-rango-YYYYMMDD-HHMM-SHA` → GitHub release name `Rango vX.Y.Z-rango.YYYYMMDD-HHMM+SHA`
+- **Channel tags**:
   - stable releases move `latest`
   - prereleases from `main` move `nightly` and `beta`
+
+## Rango Integration Skill
+
+A [Claude Code skill](skills/rango-integration/SKILL.md) is available for agentic development on Rango. It provides four modes:
+
+- **Setup**: Scaffold a new Rango workspace or integration
+- **Pattern**: Apply tested Rango patterns (sync, audit, tenant isolation)
+- **Architecture**: Validate changes against Rango's design constraints
+- **Audit**: Review code for Rango-specific correctness and safety
 
 ## Validation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,20 +115,23 @@ Workstream E — polyglot DX:
 - reference integration: LangGraph agent on Rango
 - reference integration: CrewAI agent on Rango
 
-### v0.3.0 (Capabilities Baseline)
+### v0.3.0 (Operability & Sync Baseline)
 
-Enable advanced retrieval capabilities without contaminating core truth and harden multi-node operation.
+Harden multi-node operation and make Rango operable in production environments.
 
-Workstream F — capability contracts:
-- external vector/graph capability contracts
-- adapter conformance kit (mock + golden fixtures)
-- reference adapters: pgvector, Qdrant
-- trust-aware ranking input contract + bounded context assembly docs
+Workstream F — sync hardening:
+- multi-node sync hardening (partition/heal regression suite)
+- sync idempotency verification under network failures
+- deterministic convergence tests for split-brain scenarios
 
 Workstream G — operability:
 - backup/restore CLI with optional S3 sink
-- multi-node sync hardening (partition/heal regression suite)
-- Grafana reference dashboard wired to OTel metrics
+- external read contract (how tools like LangChain/LlamaIndex read from Rango)
+- trust-aware ranking input contract + bounded context assembly docs
+
+**Deferred to post-v0.3.0:**
+- Semantic retrieval (embeddings, vector search) — requires ADR on versioning
+- External vector store adapters (pgvector, Qdrant) — Rango remains core-only
 
 ## GitHub Execution Model
 


### PR DESCRIPTION
Updates CHANGELOG.md and README.md to reflect recent changes:

**CHANGELOG:**
- StorageEngine generic erasure (#44)
- ROADMAP v0.3.0 redefinition (#51, #53)
- Documentation alignment across all docs

**README:**
- Replace 'v1 Scope' with versioned scope (v0.1.0, v0.2.0, v0.3.0)
- Add Language Bindings section (Python, Node.js)
- Add Rango Integration Skill section
- Formatting improvements